### PR TITLE
InlineParser: fix a regex error on Java

### DIFF
--- a/src/markdown/InlineParser.hx
+++ b/src/markdown/InlineParser.hx
@@ -201,7 +201,7 @@ class InlineParser
 
 	public function unescape(text:String):String
 	{
-  		text = ~/\\([\\`*_{}[\]()#+-.!])/g.replace(text, '$1');
+		text = ~/\\([\\`*_{}\[\]()#+-.!])/g.replace(text, '$1');
 		text = StringTools.replace(text, '\t', '    ');
 		return text;
 	}


### PR DESCRIPTION
On the Java target, this regex causes the following error:

>Parsing warning: java.util.regex.PatternSyntaxException: Unclosed character class near index 22
\\([\\`*_{}[\]()#+-.!])

See HaxeFoundation/haxe#4191.